### PR TITLE
polish

### DIFF
--- a/aws/lib/docs-stack.ts
+++ b/aws/lib/docs-stack.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager';
@@ -36,16 +37,27 @@ export class DocsStack extends cdk.Stack {
             code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, '../..'), {
                 platform: ecr_assets.Platform.LINUX_AMD64,
             }),
+            memorySize: 2048,
             timeout: cdk.Duration.seconds(30),
         });
 
         const api = new apigateway.LambdaRestApi(this, 'Api', {
             binaryMediaTypes: ['*/*'],
+            endpointTypes: [apigateway.EndpointType.REGIONAL],
             handler: docsHandler,
-            domainName: {
-                domainName: fullSubdomain,
-                certificate: domainCert,
+        });
+
+        const apiDist = new cloudfront.Distribution(this, 'ApiDistribution', {
+            certificate: domainCert,
+            defaultBehavior: {
+                allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+                cachePolicy: new cloudfront.CachePolicy(this, 'ApiCachePolicy', {
+                    cookieBehavior: cloudfront.CacheCookieBehavior.allowList('fftoken'),
+                }),
+                origin: new origins.RestApiOrigin(api),
+                viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             },
+            domainNames: [fullSubdomain],
         });
 
         const zone = route53.HostedZone.fromLookup(this, 'HostedZone', {
@@ -55,7 +67,7 @@ export class DocsStack extends cdk.Stack {
         new route53.ARecord(this, 'Record', {
             recordName: subDomainName,
             zone,
-            target: route53.RecordTarget.fromAlias(new targets.ApiGateway(api)),
+            target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(apiDist)),
         });
     }
 }

--- a/components/LoginPage/LoginForm.tsx
+++ b/components/LoginPage/LoginForm.tsx
@@ -14,7 +14,7 @@ export type LoginFormProps = {
 
 export const LoginForm = ({ setLoginState }: LoginFormProps) => {
     const [isBusy, setIsBusy] = useState(false);
-    const [remember, setRemember] = useState(true);
+    const [remember, setRemember] = useState(false);
     const [token, setToken] = useState('');
     const [errorMessage, setErrorMessage] = useState('');
     const router = useRouter();

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,5 @@
 {
-    "testPathIgnorePatterns": ["fixtures"],
+    "testPathIgnorePatterns": ["aws", "fixtures"],
     "transformIgnorePatterns": [],
     "transform": {
         "\\.m?[jt]sx?$": [

--- a/lib/content-loading.ts
+++ b/lib/content-loading.ts
@@ -69,8 +69,15 @@ function parseHttpMarkdownCode(code: string): ParsedHttpCodeBlock {
     };
 }
 
+let cachedContent: Map<string, Content> | undefined = undefined;
+
 // Returns a map where each key is a path, such as "/" or "/fusion-feed".
 export async function getAllContent(): Promise<Map<string, Content>> {
+    // This function can be expensive, so memoize it in production.
+    if (process.env.NODE_ENV === 'production' && cachedContent) {
+        return cachedContent;
+    }
+
     const ret = new Map();
     for await (const p of walk('./content')) {
         if (!p.endsWith('.mdx')) {
@@ -194,6 +201,8 @@ export async function getAllContent(): Promise<Map<string, Content>> {
             path: contentPath,
         });
     }
+
+    cachedContent = ret;
     return ret;
 }
 


### PR DESCRIPTION
Touches up a few things:

- The deployment now uses a much bigger Lambda function. This makes it significantly faster, but still costs virtually nothing.
- This sets up an HTTP -> HTTPS redirect. Unfortunately this had to be done using CloudFront (https://stackoverflow.com/questions/47311081/redirect-http-requests-to-https-on-aws-api-gateway-using-custom-domains). So I converted the API to a regional API and put a CloudFront distro back in front of it.
- By default, the "Remember Me" checkbox is disabled. We should be "safe by default" here.
- I had a problem with jest discovering and choking on AWS CDK artifacts, so I added ./aws to its ignore paths.
- I added memoization to the `getAllContent` function, which is very expensive and needed for most pages. In conjunction with the Lambda function change, this makes the docs pretty zippy aside from the infrequent cold-start/memoization miss.

This is deployed to demo right now, so you can go give it a spin.