### PR TITLE
add github links

### DIFF
--- a/components/DefaultPage/index.tsx
+++ b/components/DefaultPage/index.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import getConfig from 'next/config';
 import Head from 'next/head';
+import Image from 'next/image';
+import Link from 'next/link';
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote';
+
+import githubIcon from '../../node_modules/@tabler/icons/icons/brand-github.svg';
+import pullRequestIcon from '../../node_modules/@tabler/icons/icons/git-pull-request.svg';
 
 import { Footer } from '../Footer';
 import { Header } from '../Header';
@@ -17,6 +22,7 @@ const scope = {
 
 export interface Props {
     path: string;
+    filePath: string;
     source: MDXRemoteSerializeResult;
     tableOfContents: TableOfContents;
     headings: Heading[];
@@ -36,6 +42,20 @@ export const DefaultPage = (props: Props) => {
                 <NavBar toc={toc} path={props.path} />
                 <div className={styles['generated-content']}>
                     <MDXRemote {...props.source} scope={scope} />
+                    <hr className={styles['bottom-divider']} />
+                    <div className={styles['open-source-cta']}>
+                        <h6>
+                            <Image src={githubIcon.src} width={24} height={24} alt={'GitHub'} />
+                            <span>This site is open source!</span>
+                        </h6>
+                        <div className={styles['open-source-cta__content']}>
+                            <p>See something that could be improved? Open a pull request on GitHub.</p>
+                            <Link className={styles['open-source-cta__button']} href={`https://github.com/tempus-ex/docs/blob/main/${props.filePath}`} target="_blank">
+                                <Image src={pullRequestIcon.src} width={16} height={16} alt={'Pull Request'} />
+                                Contribute to This Page
+                            </Link>
+                        </div>
+                    </div>
                 </div>
                 <PageNavBar headings={props.headings} />
             </main>

--- a/components/DefaultPage/styles.module.scss
+++ b/components/DefaultPage/styles.module.scss
@@ -201,3 +201,56 @@
     }
   }
 }
+
+.bottom-divider {
+  border: 0;
+  border-top: 1px solid var(--border-color);
+  margin-top: spacing("xl");
+  margin-bottom: spacing("xl");
+}
+
+.open-source-cta {
+  h6 {
+    text-transform: none;
+
+    img {
+      margin-right: spacing("xs");
+      vertical-align: middle;
+    }
+
+    span {
+      vertical-align: middle;
+    }
+  }
+
+  // This button is designed to match GitHub's look and feel for buttons.
+  &__button {
+    font-size: 1.5rem;
+
+    background-color: rgb(246, 248, 250);
+    border: 1px solid rgb(9, 105, 218);
+    border-radius: 6px;
+    color: rgb(36, 41, 47) !important;
+    padding: 8px 18px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !important;
+    box-shadow: rgba(31, 35, 40, 0.04) 0px 1px 0px 0px, rgba(255, 255, 255, 0.25) 0px 1px 0px 0px inset;
+    font-size: 14px !important;
+    font-weight: 500 !important;
+    line-height: 20px;
+    vertical-align: middle;
+
+    img {
+      margin-right: 4px;
+      vertical-align: text-bottom;
+    }
+  }
+
+  &__content {
+    margin-left: calc(24px + spacing("xs"));
+
+    p {
+        color: rgb(101, 109, 118);
+        margin-bottom: spacing("lg");
+    }
+  }
+}

--- a/content/fusionfeed/index.mdx
+++ b/content/fusionfeed/index.mdx
@@ -26,3 +26,7 @@ It can provide many types of data, including the following:
 All API endpoints are prefixed with a major version number. The current major API version is V2. All of the current API endpoint URLs begin with <code>{config.fusionFeedUrl}/v2/</code>.
 
 Tempus Ex is committed to never making breaking changes for any given major version number. However, Tempus Ex will from time to time deprecate APIs. When this happens, those deprecated APIs will continue to work, but it is highly recommended that you upgrade to the suggested alternatives as soon as possible.
+
+## Status
+
+To subscribe to status updates for FusionFeed, please visit [status.tempus-ex.com](https://status.tempus-ex.com).

--- a/lib/content-loading.ts
+++ b/lib/content-loading.ts
@@ -249,6 +249,7 @@ export async function getAllContent(): Promise<Map<string, Content>> {
             links,
             source,
             path: contentPath,
+            filePath: p,
         });
     }
 

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -29,6 +29,7 @@ export interface Content {
     frontmatter: Frontmatter;
     source: MDXRemoteSerializeResult;
     path: string;
+    filePath: string;
     graphql: GraphQL[];
     rest: REST[];
     headings: Heading[];

--- a/pages/[...path].tsx
+++ b/pages/[...path].tsx
@@ -30,6 +30,7 @@ export const getStaticProps = async function ({ params }: { params: Params }) {
     return {
         props: {
             path,
+            filePath: content.filePath,
             source: content.source,
             tableOfContents,
             headings: content.headings,


### PR DESCRIPTION
The docs repo is now public. This adds handy dandy contribute buttons to each page:

<img width="1840" alt="Screenshot 2023-08-29 at 15 37 41" src="https://github.com/tempus-ex/docs/assets/1731074/1c27c82d-5382-4dd0-b525-41df75359462">

It also adds a link to the status site.