### PR TITLE
continuous deployment on merge to main

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,3 +30,57 @@ jobs:
         run: |
           npm ci
           npm run test
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      actions: read
+      deployments: write
+    needs:
+      - test
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::189912143729:role/ProdDocsGitHubActionsStack-Role1ABCC5F0-KyOsFJsaLrnn
+          aws-region: us-east-1
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@releases/v1
+        id: deployment
+        with:
+          token: "${{ github.token }}"
+          environment: prod
+      - name: NPM Install
+        working-directory: aws
+        run: npm ci
+      - name: Deploy
+        working-directory: aws
+        run: |
+          npx aws-cdk deploy ProdDocsStack -r arn:aws:iam::189912143729:role/ProdDocsGitHubActionsStack-UpdateRoleD9565374-i7KuEu6ZL8fY -c deployRoleArn=arn:aws:iam::189912143729:role/ProdDocsGitHubActionsStack-DeployRole885297C3-9V3OU3WKMFNF
+          aws cloudfront create-invalidation --distribution-id E3LRF6MMAY4LIQ --paths '/*'"
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          environment_url: https://docs.tempus-ex.com
+          state: "success"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          state: "failure"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,14 +1,11 @@
-# Welcome to your CDK TypeScript project
+# aws
 
-This is a blank project for CDK development with TypeScript.
+This is the CDK deployment for the docs stack.
 
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+## Deploying
 
-## Useful commands
+After installing dependencies with `npm install`, you can deploy the stack with the following command:
 
-* `npm run build`   compile typescript to js
-* `npm run watch`   watch for changes and compile
-* `npm run test`    perform the jest unit tests
-* `cdk deploy`      deploy this stack to your default AWS account/region
-* `cdk diff`        compare deployed stack with current state
-* `cdk synth`       emits the synthesized CloudFormation template
+```bash
+npx aws-cdk deploy ProdDocsStack
+```

--- a/aws/bin/aws.ts
+++ b/aws/bin/aws.ts
@@ -2,11 +2,13 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { DocsStack } from '../lib/docs-stack';
+import { GitHubActionsStack } from '../lib/github-actions-stack';
 
-const demoArn = 'arn:aws:acm:us-east-1:992150767891:certificate/c5a6eb00-528f-473d-89a7-cb64b85722e9';
-const webProdArn = 'arn:aws:acm:us-east-1:189912143729:certificate/a460ee40-07ed-4eee-b425-9bcf9303b15c';
+const DEMO_CERTIFICATE_ARN = 'arn:aws:acm:us-east-1:992150767891:certificate/c5a6eb00-528f-473d-89a7-cb64b85722e9';
+const PROD_CERTIFICATE_ARN = 'arn:aws:acm:us-east-1:189912143729:certificate/a460ee40-07ed-4eee-b425-9bcf9303b15c';
 
 const app = new cdk.App();
+
 new DocsStack(app, 'DemoDocsStack', {
     env: {
         account: '992150767891',
@@ -14,15 +16,27 @@ new DocsStack(app, 'DemoDocsStack', {
     },
     domainName: 'demo.tempus-ex.com',
     subDomainName: 'docs',
-    certificateArn: demoArn,
+    certificateArn: DEMO_CERTIFICATE_ARN,
 });
 
-new DocsStack(app, 'ProdDocsStack', {
+const prodDocsStack = new DocsStack(app, 'ProdDocsStack', {
     env: {
         account: '189912143729',
         region: 'us-east-1',
     },
     domainName: 'docs.tempus-ex.com',
     subDomainName: '',
-    certificateArn: webProdArn,
+    certificateArn: PROD_CERTIFICATE_ARN,
+    synthesizer: new cdk.DefaultStackSynthesizer({
+        deployRoleArn: app.node.tryGetContext('deployRoleArn'),
+    }),
+});
+
+new GitHubActionsStack(app, 'ProdDocsGitHubActionsStack', {
+    branch: 'main',
+    docsStack: prodDocsStack,
+    env: {
+        account: '189912143729',
+        region: 'us-east-1',
+    },
 });

--- a/aws/lib/github-actions-stack.ts
+++ b/aws/lib/github-actions-stack.ts
@@ -1,0 +1,110 @@
+import { App, Aws, aws_iam as iam, Stack, StackProps } from 'aws-cdk-lib';
+
+import { DocsStack } from './docs-stack';
+
+interface Props extends StackProps {
+    branch: string;
+    docsStack: DocsStack;
+}
+
+// Creates the resources necessary for GitHub Actions.
+//
+// Note that this does not create the GitHub Actions identity provider as that is an account-wide
+// singleton resource. As a prerequisite, you must create an identity provider for
+// "token.actions.githubusercontent.com".
+export class GitHubActionsStack extends Stack {
+    constructor(scope: App, id: string, props: Props) {
+        super(scope, id, props);
+
+        const updateRole = new iam.Role(this, 'UpdateRole', {
+            assumedBy: new iam.ServicePrincipal('cloudformation.amazonaws.com'),
+            description: 'This role can be passed to CloudFormation to update the deployment.',
+            inlinePolicies: {
+                policy: new iam.PolicyDocument({
+                    statements: [new iam.PolicyStatement({
+                        actions: ['iam:GetRole'],
+                        resources: [`arn:aws:iam::${Aws.ACCOUNT_ID}:role/${props.docsStack.stackName}-*`],
+                    }), new iam.PolicyStatement({
+                        actions: ['apigateway:GET'],
+                        resources: ['*'],
+                    }), new iam.PolicyStatement({
+                        actions: [
+                            'lambda:ListTags',
+                            'lambda:GetFunction',
+                            'lambda:UpdateFunctionCode',
+                        ],
+                        resources: [`arn:aws:lambda:${Aws.REGION}:${Aws.ACCOUNT_ID}:function:${props.docsStack.stackName}-*`],
+                    }), new iam.PolicyStatement({
+                        actions: ['ssm:GetParameters'],
+                        resources: [`arn:aws:ssm:${Aws.REGION}:${Aws.ACCOUNT_ID}:parameter/cdk-bootstrap/*/version`],
+                    })],
+                }),
+            },
+        });
+
+        const deployRole = new iam.Role(this, 'DeployRole', {
+            assumedBy: new iam.AccountPrincipal(Aws.ACCOUNT_ID),
+            description: 'This role can be passed to the CDK to perform the deployment.',
+            inlinePolicies: {
+                policy: new iam.PolicyDocument({
+                    statements: [new iam.PolicyStatement({
+                        actions: ['iam:PassRole'],
+                        resources: [updateRole.roleArn],
+                    }), new iam.PolicyStatement({
+                        actions: [
+                            'cloudformation:GetTemplate',
+                            'cloudformation:CancelUpdateStack',
+                            'cloudformation:UpdateStack',
+                            'cloudformation:CreateChangeSet',
+                            'cloudformation:DescribeChangeSet',
+                            'cloudformation:ExecuteChangeSet',
+                            'cloudformation:DeleteChangeSet',
+                            'cloudformation:DescribeStacks',
+                            'cloudformation:DescribeStackEvents',
+                            'cloudformation:GetTemplateSummary',
+                        ],
+                        resources: [`arn:aws:cloudformation:${Aws.REGION}:${Aws.ACCOUNT_ID}:stack/${props.docsStack.stackName}/*`],
+                    }), new iam.PolicyStatement({
+                        actions: ['s3:GetObject*', 's3:GetBucket*', 's3:List*'],
+                        resources: [
+                            `arn:aws:s3:::cdk-*-assets-${Aws.ACCOUNT_ID}-${Aws.REGION}`,
+                            `arn:aws:s3:::cdk-*-assets-${Aws.ACCOUNT_ID}-${Aws.REGION}/*`,
+                        ],
+                    }), new iam.PolicyStatement({
+                        actions: ['cloudformation:DescribeStacks'],
+                        resources: [`arn:aws:cloudformation:${Aws.REGION}:${Aws.ACCOUNT_ID}:stack/CDKToolkit/*`],
+                    }), new iam.PolicyStatement({
+                        actions: ['ssm:GetParameter'],
+                        resources: [`arn:aws:ssm:${Aws.REGION}:${Aws.ACCOUNT_ID}:parameter/cdk-bootstrap/*/version`],
+                    })],
+                }),
+            },
+        });
+
+        new iam.Role(this, 'Role', {
+            assumedBy: new iam.FederatedPrincipal(`arn:aws:iam::${Aws.ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com`, {
+                StringEquals: {
+                    'token.actions.githubusercontent.com:sub': `repo:tempus-ex/docs:ref:refs/heads/${props.branch}`,
+                    'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+                },
+            }, 'sts:AssumeRoleWithWebIdentity'),
+            inlinePolicies: {
+                policy: new iam.PolicyDocument({
+                    statements: [new iam.PolicyStatement({
+                        actions: ['iam:AssumeRole'],
+                        resources: [deployRole.roleArn],
+                    }), new iam.PolicyStatement({
+                        actions: ['cloudfront:CreateInvalidation'],
+                        resources: ['*'],
+                    }), new iam.PolicyStatement({
+                        actions: ['cloudformation:DescribeStacks'],
+                        resources: [`arn:aws:cloudformation:${Aws.REGION}:${Aws.ACCOUNT_ID}:stack/CDKToolkit/*`],
+                    }), new iam.PolicyStatement({
+                        actions: ['ssm:GetParameter'],
+                        resources: [`arn:aws:ssm:${Aws.REGION}:${Aws.ACCOUNT_ID}:parameter/cdk-bootstrap/*/version`],
+                    })],
+                }),
+            },
+        });
+    }
+}


### PR DESCRIPTION
This adds a new CDK stack: the GitHub Actions stack. This stack defines three roles:

- A role that can be assumed by GitHub Actions to assume a deploy role.
- A deploy role that can be used to trigger the CloudFormation deploy and pass the update role to it.
- An update role that allows the operations needed by CloudFormation to do a typical update (usually just update a Lambda function).

It adds a step to GitHub actions to deploy to prod on merge to main.

I've tested each of these roles and have tested deploys by assuming them locally. I've done about as much testing as I can without actually merging. If this breaks after being merged to main, I'll follow up with fixes.